### PR TITLE
Clean up readme.txt

### DIFF
--- a/AEGIS_25.2_training_sample_readme.txt
+++ b/AEGIS_25.2_training_sample_readme.txt
@@ -1,35 +1,36 @@
 This README file describes the AEGIS F814W<25.2 training sample, which is a
-random(fair) subsample of all galaxies in the AEGIS field in 
-F606w and F814W bands. 
+random(fair) subsample of all galaxies in the AEGIS field in
+F606w and F814W bands.
 
-NOTE: The fields in the catalog are identical to real_galaxy_catalog in GalSim. 
-However, some parts of the analysis were not performed(e.g. parametric fits). 
-Hence those values were manually set, and do not have physical meaning   
+NOTE: The fields in the catalog are those expected by galsim.RealGalaxyCatalog.
+However, some parts of the analysis were not performed(e.g. parametric fits).
+Hence those values were manually set, and do not have physical meaning.
 
-(1) The catalog(s) itself is AEGIS_galaxy_catalog_I(V)_25.2.fits.  These files 
-can be used to initialize a galsim.RealGalaxyCatalog or galsim.COSMOSCatalog 
-instance, and contains\ a FITS table that could also be read in directly using
-e.g. python or IDL.  The fields that are included for each 
-galaxy are:
+(1) The catalogs themselves are in AEGIS_galaxy_catalog_[VI]_25.2.fits (where
+[VI] indicates either V or I).  These files can be used to initialize a
+galsim.RealGalaxyCatalog or galsim.COSMOSCatalog instance, and contain a FITS
+tables that could also be  read in directly using, e.g., python or IDL.  The
+fields that are included for each galaxy are:
 
-IDENT: AEGIS object identifier. This value is internally derived. Therefore 
+IDENT: AEGIS object identifier. This value is internally derived.  Therefore
 do not rely on this IDENT for cross-matching between other AEGIS catalogs.
 
-RA, DEC: Right ascension and declination (J2000, degrees).  While this is not 
-needed for image simulation, it is necessary for proper cross-matching with 
+RA, DEC: Right ascension and declination (J2000, degrees).  While this is not
+needed for image simulation, it is necessary for proper cross-matching with
 other catalogs.
 
 MAG: magnitude (MAG_AUTO calculated from sextractor).
 
 BAND: Passband for the observed image (F814W/F606W).
 
-WEIGHT: A weight factor to use to account for the fact that larger galaxies are 
-preferentially excluded from this catalog due to the proximity to CCD edges (Set to 1).
+WEIGHT: A weight factor to use to account for the fact that larger galaxies are
+preferentially excluded from this catalog due to the proximity to CCD edges.
+(Currently all weights are set to 1.0).
 
-GAL_FILENAME: Name of the file containing the galaxy image.  This is just a 
+GAL_FILENAME: Name of the file containing the galaxy image.  This is just a
 filename, not including a full path.
 
-PSF_FILENAME: Name of the file containing the PSF image for this galaxy.  
+PSF_FILENAME: Name of the file containing the PSF image for this galaxy.
 This is just a filename, not including a full path.
 
 GAL_HDU: HDU containing the image of this galaxy in the file called GAL_FILENAME.
@@ -43,19 +44,19 @@ NOISE_MEAN: mean value of the pixels in the image that do not contain the galaxy
 NOISE_VARIANCE: variance of the pixel values for pixels in the image that do not contain the galaxy.
 
 
-(2) The files containing galaxy and PSF images are AEGIS_galaxy_images_I(V)_25.2_n?.fits and
-AEGIS_galaxy_PSF_images_I(V)_25.2_n?.fits. The number that goes in place of
-the "?" ranges from 0 to 29.
+(2) The files containing galaxy and PSF images are
+AEGIS_galaxy_images_[VI]_25.2_n?.fits. The number that goes in place of the "?"
+ranges from 0 to 29.
 
 
 (3) *Parametric fits have not been performed and the values in the table were manually set.*
-A catalog containing information about the fits to the galaxies in 
-AEGIS_galaxy_catalog_I(V)_25.2.fits, using the fitting code from Lackner & 
-Gunn (2012, MNRAS, 421, 2277) as described in the GREAT3 challenge handbook. 
-The catalog of fit information is AEGIS_galaxy_catalog_I(V)_25.2_fits.fits 
-(a FITS table), and the entries are in the same order as in 
+A catalog containing information about the fits to the galaxies in
+AEGIS_galaxy_catalog_[VI]_25.2.fits, using the fitting code from Lackner &
+Gunn (2012, MNRAS, 421, 2277) as described in the GREAT3 challenge handbook.
+The catalog of fit information is AEGIS_galaxy_catalog_I(V)_25.2_fits.fits
+(a FITS table), and the entries are in the same order as in
 AEGIS_galaxy_catalog_I(V)_25.2.fits.  The instructions below tell how to use
-the entries in this file to construct galaxy images; however, if you use the 
+the entries in this file to construct galaxy images; however, if you use the
 COSMOSCatalog class, GalSim will take care of these details for you.  The file
 contains the following fields:
 
@@ -63,81 +64,37 @@ IDENT: AEGIS identifier.
 
 MAG_AUTO: magnitude (MAG_AUTO computed by SExtractor).
 
-FLUX_RADIUS: half-light radius for the PSF-convolved object (same as flux_radius from the AEGIS catalog), in units of pixels.
+FLUX_RADIUS: half-light radius for the PSF-convolved object (same as flux_radius from the AEGIS
+    catalog), in units of pixels.
 
-ZPHOT: Photometric redshift from the DEEP2 galaxy redshift catalog Data Realase 4 (Newman et al. 2003).
+ZPHOT: Photometric redshift from the DEEP2 galaxy redshift catalog Data Realase 4 (Newman et al.
+    2003).
 
-SERSICFIT: An array of 8 numbers which are the results of fitting the galaxy image to a single Sersic profile with free n.  The array entries are:
+SERSICFIT: Not used.
 
-       SERSICFIT[0]: I, defined as the intensity at the half-light radius.
-       SERSICFIT[1]: R_{1/2}, the half-light radius measured along the major axis, in pixels.
-       SERSICFIT[2]: Sersic n.
-       SERSICFIT[3]: q, the ratio of minor axis to major axis length.
-       SERSICFIT[4]: boxiness (fixed to 0, for elliptical isophotes).
-       SERSICFIT[5]: x0, the central x position in pixels.
-       SERSICFIT[6]: y0, the central y position in pixels.
-       SERSICFIT[7]: phi, the position angle in radians (if phi=0, the major axis is lined up with
-                     the x axis of the image).
+BULGEFIT: Not used.
 
-       GalSim wants to know the half-light radius that is the geometric mean of the major and minor
-       axis lengths, and typically works in terms of arcsec (where the scale is always 0.03"/pixel),
-       so when initializing the galsim.Sersic object, use a half-light-radius of 
-       hlr=0.03*sqrt(q)*R_{1/2}.
+FIT_STATUS: Not used.
 
-       To relate these quantities to the object total flux that is needed to define the object in
-       GalSim, use the value of b_n for that Sersic n, and define
-       flux = 2pi*n*Gamma[2n]*exp(b_n)*q*R_{1/2}^2*I/(b_n^(2n)).
-       The factor of q is necessary because of how the light profile was defined using the intensity
-       and R_{1/2} along the major axis.  This flux will give an image that looks
-       like the HST image when the draw() method uses 'flux' normalization (the default setting).
+FIT_MAD_S: Not used.
 
-       Note: if you use the GalSim COSMOSCatalog() class, it will automatically take this file and
-       construct the galaxy light profiles for you; there is no need to do the above calculations in
-       that case. (Manually set to 0)
+FIT_MAD_B: Not used.
 
-BULGEFIT: An array of 16 numbers which are the results of fitting the galaxy image to a de
-Vaucouleurs bulge plus an exponential disk.  The array entries are the same as
-for SERSICFIT, with 8 numbers for the disk followed by 8 for the bulge.  In 
-this case, the disk and bulge values of n are
-fixed to 1 and 4, respectively, and they are required to have the same centroid. (Manually set to 0)
+FIT_DVC_BTT: Not used.
 
-FIT_STATUS: An array of 5 numbers indicating the status of the fit.  The first of those numbers is
-the status for BULGEFIT, and the last of those 5 numbers is the status for SERSICFIT.  A status of 0
-or 5 indicates failure. The GalSim COSMOSCatalog() class automatically uses this information to
-decide which kind of parametric profile to construct. (Manually set to 0).
+USE_BULGEFIT: Not used.
 
-FIT_MAD_S: the median absolute deviation between the image and the SERSICFIT model, as determined in
-a region containing primarily pixels in the galaxy (not sky).  This can be used comparatively with
-FIT_MAD_B to determine which is a better description of the galaxy.  The GalSim COSMOSCatalog() class
-automatically uses this information to decide which kind of parametric profile to construct. (Manually set to 0).
+VIABLE_SERSIC: Not used.
 
-FIT_MAD_B: same as FIT_MAD_S, but for the BULGEFIT model. (Manually set to 0).
+HLR: Not used.
 
-FIT_DVC_BTT: The bulge-to-total flux ratio (B/T) for the 2-component BULGEFIT. (Manually set to 0).
-
-USE_BULGEFIT: A flag that uses information from FIT_STATUS, FIT_MAD_*, and other information about
-the fits to decide whether or not to use the 2-component fits.  It has a value of 1 if the
-two-component fit is viable, 0 if not. (Manually set to 0).
-
-VIABLE_SERSIC: A flag that says whether the Sersic fit is a viable way of representing the galaxy
-(generally equal to 1, or True, except for very rare cases).  For galaxies that have USE_BULGEFIT=1
-and VIABLE_SERSIC=1, the two-component fit is likely a better representation of the light profile,
-but the sersic fit can be used if desired. (Manually set to 0).
-
-HLR: This is an Nx3 array of the circularly-averaged half-light radii in arcsec.  The 1st value is
-the half-light radius for the Sersic fit (or 0 for those with VIABLE_SERSIC=0), while the 2nd and
-3rd values are the half-light radii for the bulge and disk for the two-component fits (or 0 for
-those with USE_BULGEFIT=0).  This information is precomputed for use by the GalSim COSMOSCatalog()
-class. (Manually set to 0).
-
-FLUX: This is an Nx4 array of the flux.  The 1st value is the flux for the Sersic fit (or 0 for
-those with VIABLE_SERSIC=0), while the 2nd and 3rd values are the fluxes for the bulge and disk for
-the two-component fits (or 0 for those with USE_BULGEFIT=0).  This information is precomputed for
-use by the GalSim COSMOSCatalog() class. (Manually set to 0).
+FLUX: Not used.
 
 
-(4) Files (AEGIS_galaxy_catalog_I(V)_25.2_selection.fits) with some selection flags that the GalSim
-COSMOSCatalog class may use to impose selection criteria on the quality of the postage stamps and/or fits.
+(4) Files (AEGIS_galaxy_catalog_[VI]_25.2_selection.fits) with some selection
+flags that the GalSim COSMOSCatalog class may use to impose selection criteria
+on the quality of the postage stamps and/or fits.
 
 
-(5) Files acs_I(V)_unrot_sci_20_cf.fits containing information that GalSim needs to understand the noise fields in the postage stamps.
+(5) Files acs_[VI]_unrot_sci_20_cf.fits containing information that GalSim
+needs to understand the noise fields in the postage stamps.


### PR DESCRIPTION
Hi Sowmya,

I went through AEGIS_25.2_training_sample_readme.txt and made some edits.  You should be able to see this through the github.com pull request tab for this repo.  Mostly just rewording a few things.  If you have questions about the changes, you should be able to click on the line numbers and enter them there.  If/when you're happy with everything, you can merge the pull request into your fork.

I do have one question: where you say these gals are a fair subsample, is the fact that they're a subsample just because you made a magnitude (and a size) cut?  Is the same true for the COSMOS_25.2 catalog?  My impression for COSMOS was that the subsampling was just to keep the size of the catalog manageable, which is a different situation than you have I think.  We should track this down.

My only other comment is that I think it would be nice if you used very obviously wrong sentinel values for the parametric fits fields in the output.  Something like -999 instead of just 0.

-Josh
